### PR TITLE
fix splt shape < 64 issue & add num_kv_heads to mp_params

### DIFF
--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -388,7 +388,7 @@ class AutoTP():
             return
         for param in [
                 "n_heads", "inner_dim", "num_heads", "num_kv", "num_attention_heads", "num_attn_heads",
-                "all_head_size", "embed_dim", "hidden_size", "num_key_value_heads"
+                "all_head_size", "embed_dim", "hidden_size", "num_key_value_heads", "num_kv_heads"
         ]:
             if hasattr(child, param):
                 param_val = getattr(child, param)

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -274,7 +274,7 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
 
         # 3. Try to get num_key_heads from model_config.num_key_value_heads
         num_kv_heads = None
-        kv_head_names = ['num_key_value_heads', 'num_attention_heads', 'n_heads']
+        kv_head_names = ['num_kv_heads', 'num_key_value_heads', 'num_attention_heads', 'n_heads']
         for name in kv_head_names:
             if hasattr(model_config, name):
                 num_kv_heads = getattr(model_config, name)

--- a/deepspeed/module_inject/tp_shard.py
+++ b/deepspeed/module_inject/tp_shard.py
@@ -28,8 +28,11 @@ def get_shard_size(total_size, mp_size, name=None, rank=None):
         my_slices = (num_kv_heads // mp_size) + (1 if rank < (num_kv_heads % mp_size) else 0)
         return total_size * my_slices // num_kv_heads
     else:
-        grain_size = total_size // 64
-        return (grain_size // mp_size + (1 if rank < (grain_size % mp_size) else 0)) * 64
+        if total_size >= 64:
+            grain_size = total_size // 64
+            return (grain_size // mp_size + (1 if rank < (grain_size % mp_size) else 0)) * 64
+        else:
+            return total_size // mp_size + (1 if rank < (total_size % mp_size) else 0)
 
 
 def get_shard_size_list(total_size, mp_size, name=None):


### PR DESCRIPTION
1. When split shape(total_size) < 64, tp sharding will fail. We have added support for split_shape < 64.
2. falcon-40b will fail on SNC3. This reason is falcon-40b kv_head_names is "num_kv_heads". Need to add this name in mp_param list and kv_head_names list.