### PR TITLE
fix falcon-40b accuracy issue

### DIFF
--- a/deepspeed/module_inject/fusedqkv_utils.py
+++ b/deepspeed/module_inject/fusedqkv_utils.py
@@ -37,6 +37,7 @@ def prepare_tp_fused_qkvw(module_str, src, mp_size, gpu_index):
         'GLMBlock': 'glmtype',
         "MPTBlock": 'glmtype',
         "MptBlock": 'glmtype',
+        "FalconDecoderLayer": 'bloomtype',
         "BaichuanLayer": 'glmtype',
         "DecoderLayer": 'glmtype',
         "GPTBigCodeBlock": 'bigcodetype'  # starcoder


### PR DESCRIPTION
"FalconDecoderLayer" module will choose the "glmtype" fused_qkv_type. But the Falcon model should use the "bloomtype". 