### PR TITLE
fix t5 and mistral model load from config meta tensor bug

### DIFF
--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -122,7 +122,7 @@ class Loading():
     def is_load_module(module):
         load_layers = [nn.Linear, nn.Embedding, nn.LayerNorm]
         load_layer_names = [
-            "LPLayerNorm", "SharedEmbedding", "OPTLearnedPositionalEmbedding", "LlamaRMSNorm", "RMSNorm"
+            "LPLayerNorm", "SharedEmbedding", "OPTLearnedPositionalEmbedding", "LlamaRMSNorm", "RMSNorm", "MistralRMSNorm", "T5LayerNorm",
         ]
         return module.__class__ in load_layers or module._get_name() in load_layer_names
 


### PR DESCRIPTION
Verified the performance and accuracy are the same as load from pretrain.

t5 acc
|     Task     |Version|Metric|Value |   |Stderr|
|--------------|------:|------|-----:|---|-----:|
|lambada_openai|      0|ppl   |4.1306|±  |0.1503|
|              |       |acc   |0.7233|±  |0.0062|

|     Task     |Version|Metric|Value |   |Stderr|
|--------------|------:|------|-----:|---|-----:|
|lambada_openai|      0|ppl   |4.1306|±  |0.1503|
|              |       |acc   |0.7233|±  |0.0062|

mistral acc
|     Task     |Version|Metric|Value |   |Stderr|
|--------------|------:|------|-----:|---|-----:|
|lambada_openai|      0|ppl   |3.1808|±  |0.0583|
|              |       |acc   |0.7553|±  |0.0060|

|     Task     |Version|Metric|Value |   |Stderr|
|--------------|------:|------|-----:|---|-----:|
|lambada_openai|      0|ppl   |3.1808|±  |0.0583|
|              |       |acc   |0.7553|±  |0.0060|

t5 perf on spr of diamond with 2 ranks single node:
Inference latency: 0.733 sec.

mistral:
InfInference latency: 1.416 sec.


