### PR TITLE
Add support for IMPI Thread-Split mode using OpenMP

### DIFF
--- a/csrc/cpu/comm/ccl.cpp
+++ b/csrc/cpu/comm/ccl.cpp
@@ -278,6 +278,7 @@ void inference_all_reduce(torch::Tensor& data, py::object op)
 
     switch (data.scalar_type()) {
         case c10::ScalarType::BFloat16: data_size = numel * 2; break;
+        case c10::ScalarType::Half: data_size = numel * 2; break;
         case c10::ScalarType::Float: data_size = numel * 4; break;
         default: data_type_fallback = true;
     }

--- a/csrc/cpu/comm/coll_mpi.hpp
+++ b/csrc/cpu/comm/coll_mpi.hpp
@@ -4,6 +4,7 @@
 #include <torch/extension.h>
 
 void init_mpi(void);
+void init_mpi_thread_comms(void);
 void mpi_all_reduce(int world_size, int rank, void* buf, size_t data_size, size_t numel, c10::ScalarType scalar_type);
 
 #endif //_COLL_MPI__HPP_


### PR DESCRIPTION
- Add BF16 and Float16 datatype support.

- Add support for duplicating communicators for each OpenMP thread.

- Use OpenMP inside mpi_all_reduce to split msg across threads/comms.

- If HANDOFF is defined to 1 at top of coll_mpi.cpp, do not use thread-split.